### PR TITLE
Fixup CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,13 +26,13 @@ cache:
   - '%USERPROFILE%\.cargo'
 install:
   - ps: |
-        $env:PATH += ";C:\rust\bin";
+        $env:PATH += ";${env:USERPROFILE}\.cargo\bin";
         if ($env:platform -eq 'x86') {
-          $arch_expanded = "i686-pc-windows-${env:BUILD_TARGET}";
+          $env:RUST_ARCH = "i686-pc-windows-${env:BUILD_TARGET}";
           $env:ARCH = "x86";
           $env:bits = "32";
         } else {
-          $arch_expanded = "x86_64-pc-windows-${env:BUILD_TARGET}";
+          $env:RUST_ARCH = "x86_64-pc-windows-${env:BUILD_TARGET}";
           $env:ARCH = "amd64";
           $env:bits ="64";
         }
@@ -40,18 +40,11 @@ install:
           $env:PATH += ";C:\msys64\mingw${env:bits}\bin";
           gcc --version;
         }
-        if ($env:RUST_VERSION -eq 'stable') {
-          echo "Downloading $channel channel manifest";
-          Start-FileDownload "https://static.rust-lang.org/dist/channel-rust-stable";
-
-          $env:RUST_VERSION = Get-Content channel-rust-stable | Select -first 1 | %{$_.split('-')[1]}
-        }
-        $env:rust_installer = "rust-${env:RUST_VERSION}-${arch_expanded}.exe";
-  - curl --show-error --location --retry 5 --output rust-installer.exe https://static.rust-lang.org/dist/%rust_installer%
-  - .\rust-installer.exe /VERYSILENT /NORESTART /DIR="C:\rust"
+  - curl --fail --retry 3 --silent --show-error --location -o rustup-init.exe https://win.rustup.rs
+  - rustup-init.exe --default-host %RUST_ARCH% --default-toolchain %RUST_VERSION% -y
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %ARCH%
   - rustc -vV
   - cargo -vV
 build: false
 test_script:
-  - cargo test --verbose --no-default-features
+  - cargo test --no-default-features

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
-sudo: false
+sudo: required
 language: rust
 
-# necessary for `travis-cargo coveralls --no-sudo`
+# necessary for `cargo coveralls`
 addons:
   apt:
     packages:
     - libcurl4-openssl-dev
     - libelf-dev
     - libdw-dev
-    - binutils-dev # needed for --verify
+    - binutils-dev
 
 os:
 - linux
@@ -17,8 +17,6 @@ dist: trusty
 
 cache:
   cargo: true
-  directories:
-  - $HOME/.cache/pip
 
 rust:
 - nightly
@@ -47,7 +45,7 @@ matrix:
           - libcurl4-gnutls-dev # different curl to not conflict with i386 openssl
           - libelf-dev
           - libdw-dev
-          - binutils-dev # needed for --verify
+          - binutils-dev
           - gcc-multilib # Cross compiler and cross compiled C libraries
           - libssl-dev:i386
   - os: linux # 32-bit Linux (glibc)
@@ -62,7 +60,7 @@ matrix:
           - libcurl4-gnutls-dev # different curl to not conflict with i386 openssl
           - libelf-dev
           - libdw-dev
-          - binutils-dev # needed for --verify
+          - binutils-dev
           - gcc-multilib # Cross compiler and cross compiled C libraries
           - libssl-dev:i386
   - os: linux # 32-bit Linux (glibc)
@@ -77,7 +75,7 @@ matrix:
           - libcurl4-gnutls-dev # different curl to not conflict with i386 openssl
           - libelf-dev
           - libdw-dev
-          - binutils-dev # needed for --verify
+          - binutils-dev
           - gcc-multilib # Cross compiler and cross compiled C libraries
           - libssl-dev:i386
   - os: linux # 64-bit Linux (glibc)
@@ -109,7 +107,6 @@ after_success: ci/after_success.sh
 
 env:
   global:
-  - TRAVIS_CARGO_NIGHTLY_FEATURE=""
-  - PATH=$HOME/Library/Python/2.7/bin:$HOME/.local/bin:$PATH
+  - PATH=$HOME/.local/bin:$PATH
   # encrypted github token for doc upload
   - secure: "ttZL5OpzNMQOHuaTj7cKyl5N24r3HPB0V/ogWt4Ws10t08aGoonlRSLVlUZaTKI9D5CZMthaWbHRczeJ0DO3MFvAyKcMsnBaM+hc04oRAK7GweoOW3AeKGhBGOVljQK47ySa/Bjniky9zejw/8gzHyOeji+Ydb6YwAdgxTqaHGL+5YAoB1CurxdoVZnVaCLLvvsbPsL27YFkOZrYsI51OlTzkoXj783GowgwjTWc6DBzIgtMTokBKkoPIvVRFBHpwrLhX/pvet3bauXrn2WGkl8+Ab5mBOEhwpmz9TkQW47qyWbibpOwkTwf55C7Ecpi1Aix5o21wLKEDdcZgzY72ri7DillNkLgbcIpHGBQpT+P1lK6pmG1G9HzW2bNPn8k0LukEIY8E0Q1kDef7mc4qw5zkMTgyruRi+yd6r9pTXXh1mDTvNc956Rx/fsfHgxhJIk73/IlYNIaDcmMHbyYQ/AeohWaxup45fqNRaK8AbYFm5rV3o6Ce9c+lW2cHm3ssbhQ5T6L8kGyrDO9glEeyvdKsO6lXRc6x0hiwu9msuRyCgDW1iPD0mkXiMYM5MVC3mg/h9E+e0KcjZg1+PaVqnUWHINsGynNJCctzCmfUMb9aufPTAtoYweT7FMTHekaTLhvxjaYxfPsVmi7kL6HaXAVKQf2qZgp/IjI7AtFsaE="

--- a/ci/after_success.sh
+++ b/ci/after_success.sh
@@ -1,12 +1,11 @@
-#!/bin/bash
+#!/bin/bash -e
 
-set -e
-if test "$TARGET" = "x86_64-unknown-linux-gnu"; then
+if test "$TARGET" = "x86_64-unknown-linux-gnu" -a "$TRAVIS_RUST_VERSION" = "stable"; then
     # upload the documentation from the build with stable (automatically only actually
     # runs on the master branch, not individual PRs)
-    travis-cargo --only stable doc-upload
+    cargo doc-upload
     # measure code coverage and upload to coveralls.io (the verify
     # argument mitigates kcov crashes due to malformed debuginfo, at the
     # cost of some speed <https://github.com/huonw/travis-cargo/issues/12>)
-    travis-cargo --only stable coveralls --no-sudo --verify --exclude-pattern=/test.rs,*.c,openssl-sys
+    cargo coveralls --exclude-pattern=/test.rs,*.c,openssl-sys
 fi

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -1,6 +1,4 @@
-#!/bin/bash
-
-set -xe
+#!/bin/bash -xe
 
 # Mostly from https://github.com/japaric/rust-everywhere
 # Load the correct rust if it's not already there
@@ -11,23 +9,7 @@ case $TARGET in
   i686-apple-darwin | \
   i686-unknown-linux-gnu | \
   x86_64-unknown-linux-musl)
-    if test "$TRAVIS_RUST_VERSION" = "stable"; then
-        # e.g. 1.6.0
-        version=$(rustc -V | cut -d' ' -f2)
-    else
-        version=$TRAVIS_RUST_VERSION
-    fi
-    tarball=rust-std-${version}-${TARGET}
-
-    # Cannot use wget due to https://github.com/travis-ci/travis-ci/issues/5156
-    curl -O https://static.rust-lang.org/dist/${tarball}.tar.gz
-
-    tar xzf ${tarball}.tar.gz
-
-    ${tarball}/install.sh --prefix=$(rustc --print sysroot)
-
-    rm -r ${tarball}
-    rm ${tarball}.tar.gz
+    rustup target add --toolchain $TRAVIS_RUST_VERSION $TARGET
     ;;
   # Nothing to do for native builds
   *) ;;

--- a/ci/before_script.sh
+++ b/ci/before_script.sh
@@ -1,15 +1,13 @@
-#!/bin/bash
+#!/bin/bash -e
 
-set -e
-
-# load travis-cargo
-pip install 'travis-cargo<0.2' --user
-
-test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update
-test -x $HOME/.cargo/bin/rustfmt || cargo install rustfmt
-cargo install-update rustfmt
-
-if test "$TRAVIS_RUST_VERSION" = "nightly"; then
-    test -x $HOME/.cargo/bin/cargo-clippy || cargo install clippy
-    cargo install-update clippy
+if test "$TRAVIS_RUST_VERSION" != "stable"; then
+    rustup component add rustfmt-preview --toolchain=$TRAVIS_RUST_VERSION
 fi
+
+cargo install cargo-update || echo "cargo-update already installed"
+cargo install cargo-travis || echo "cargo-travis already installed"
+if test "$TRAVIS_RUST_VERSION" = "nightly"; then
+    cargo install clippy || echo "Clippy already installed"
+fi
+
+cargo install-update -a

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -3,12 +3,14 @@
 cargo test --target $TARGET
 
 if test "$TRAVIS_OS_NAME" = "linux" -a "$TARGET" = "x86_64-unknown-linux-gnu"; then
-    travis-cargo --only stable doc
-
-    if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-        cargo fmt -- --write-mode=diff $(git diff --name-only "$TRAVIS_COMMIT" "$TRAVIS_BRANCH" | grep \.rs$)
+    if test "$TRAVIS_RUST_VERSION" = "stable"; then
+        cargo doc
     else
-        cargo fmt -- --write-mode=diff $(git show --format= --name-only "$TRAVIS_COMMIT_RANGE" | sort -u | grep \.rs$)
+        if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+            cargo fmt -- --write-mode=diff $(git diff --name-only "$TRAVIS_COMMIT" "$TRAVIS_BRANCH" | grep \.rs$)
+        else
+            cargo fmt -- --write-mode=diff $(git show --format= --name-only "$TRAVIS_COMMIT_RANGE" | sort -u | grep \.rs$)
+        fi
     fi
 fi
 

--- a/src/imp/cryptoapi.rs
+++ b/src/imp/cryptoapi.rs
@@ -110,9 +110,7 @@ impl Hasher {
             hcrypthash: 0,
         };
 
-        call!(unsafe {
-            CryptCreateHash(ret.hcryptprov, hash_type, 0, 0, &mut ret.hcrypthash)
-        });
+        call!(unsafe { CryptCreateHash(ret.hcryptprov, hash_type, 0, 0, &mut ret.hcrypthash) });
         ret
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -22,7 +22,7 @@
 
 use hex;
 use std::io::Write;
-use super::{Algorithm, Hasher, hex_digest};
+use super::{hex_digest, Algorithm, Hasher};
 
 // From Wikipedia
 const MD5_EMPTY_STRING: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
@@ -70,9 +70,9 @@ fn hasher_sans_write() {
 #[test]
 fn hasher_with_write() {
     let mut hasher = Hasher::new(Algorithm::MD5);
-    hasher.write_all(TO_HASH.as_bytes()).expect(
-        "Could not write to hasher",
-    );
+    hasher
+        .write_all(TO_HASH.as_bytes())
+        .expect("Could not write to hasher");
     let actual = hex::encode(hasher.finish());
     assert_eq!(TO_HASH_MD5, actual)
 }


### PR DESCRIPTION
* Use `rustfmt-preview` in beta/nightly (can probably use it in stable once Rust 1.24.0 is released) and fix some code style.
* Refactor CI config/scripts to rely on [`rustup`](https://github.com/rust-lang-nursery/rustup.rs) instead of bespoke code largely copied from other places.
* Replace `travis-cargo` with `cargo-travis`.