### PR TITLE
CI: Update rustfmt and clippy component names

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -7,7 +7,7 @@ install_cargo_travis() {
 }
 
 install_style_docs_dependencies() {
-    rustup component add rustfmt-preview clippy-preview --toolchain=$TRAVIS_RUST_VERSION
+    rustup component add rustfmt clippy --toolchain=$TRAVIS_RUST_VERSION
     install_cargo_travis
 }
 


### PR DESCRIPTION
Clippy and rustfmt are now available without the `-preview` postfix. (https://github.com/rust-lang/rust/pull/56081)