### PR TITLE
feat: add missing derives for Algorithm

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ mod test;
 pub use imp::Hasher;
 
 /// Available cryptographic hash functions.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Algorithm {
     /// Popular message digest algorithm, only available for backwards compatibility purposes.
     MD5,


### PR DESCRIPTION
I require this for the following scenario, porting some C logic into Rust. It attempts to find the greatest possible checksum for an array of possible checksums, starting with SHA512 and gradually downgrading to SHA1.

```rust
const ALGORITHMS: &[Algorithm] = &[Algorithm::SHA512, Algorithm::SHA256, Algorithm::SHA1];

/// Based on libfwupd/fwupd-common.c
pub fn checksum_guess_kind(checksum: &str) -> Algorithm {
    match checksum.len() {
        32 => Algorithm::MD5,
        40 => Algorithm::SHA1,
        64 => Algorithm::SHA256,
        128 => Algorithm::SHA512,
        _ => Algorithm::SHA1,
    }
}

/// Find the best checksum available for an array of checksums.
pub fn find_best_checksum<S: AsRef<str>>(checksums: &[S]) -> Option<(&str, Algorithm)> {
    for &algorithm in ALGORITHMS {
        for checksum in checksums {
            if algorithm == checksum_guess_kind(checksum.as_ref()) {
                return Some((checksum.as_ref(), algorithm));
            }
        }
    }

    None
}
```