### PR TITLE
build: pin cross to v0.1.16

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -23,18 +23,13 @@ install_compile_dependencies() {
     local target=
     if [ $TRAVIS_OS_NAME = linux ]; then
         target=x86_64-unknown-linux-musl
-        sort=sort
     else
         target=x86_64-apple-darwin
-        sort=gsort  # for `sort --sort-version`, from homebrew's coreutils.
     fi
 
-    # This fetches latest stable release
-    local tag=$(git ls-remote --tags --refs --exit-code https://github.com/rust-embedded/cross \
-                       | cut -d/ -f3 \
-                       | grep -E '^v[0.1.0-9.]+$' \
-                       | $sort --version-sort \
-                       | tail -n1)
+    # Pinning to v0.1.16 because v0.2 removes openssl from the images
+    # https://github.com/rust-embedded/cross/pull/322
+    local tag=v0.1.16
     curl -LSfs https://japaric.github.io/trust/install.sh | \
         sh -s -- \
            --force \


### PR DESCRIPTION
v0.2 removes openssl from the images.
See: https://github.com/rust-embedded/cross/pull/322