### PR TITLE
Add `finish_into` to write the hash to a user provided buffer.

### DIFF
--- a/src/imp/commoncrypto.rs
+++ b/src/imp/commoncrypto.rs
@@ -66,6 +66,19 @@ impl Hasher {
             Err(error) => panic!("CommonCrypto error: {}", error),
         }
     }
+
+    /// Generate a digest from the data written to the `Hasher`. `dest` must be
+    /// exactly the length of the digest.
+    pub fn finish_into(&mut self, dest: &mut [u8]) {
+        let Hasher(ref mut hasher) = *self;
+        match hasher.finish() {
+            Ok(digest) => {
+                assert_eq!(dest.len(), digest.len());
+                dest.copy_from_slice(&digest);
+            }
+            Err(error) => panic!("CommonCrypto error: {}", error),
+        }
+    }
 }
 
 impl io::Write for Hasher {

--- a/src/imp/openssl.rs
+++ b/src/imp/openssl.rs
@@ -70,6 +70,19 @@ impl Hasher {
             Err(error_stack) => panic!("OpenSSL error(s): {}", error_stack),
         }
     }
+
+    /// Generate a digest from the data written to the `Hasher`. `dest` must be
+    /// exactly the length of the digest.
+    pub fn finish_into(&mut self, dest: &mut [u8]) {
+        let Hasher(ref mut hasher) = *self;
+        match hasher.finish() {
+            Ok(digest) => {
+                assert_eq!(dest.len(), digest.len());
+                dest.copy_from_slice(&digest)
+            }
+            Err(error_stack) => panic!("OpenSSL error(s): {}", error_stack),
+        }
+    }
 }
 
 impl io::Write for Hasher {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,8 +97,36 @@ pub enum Algorithm {
 /// ```
 pub fn digest(algorithm: Algorithm, data: &[u8]) -> Vec<u8> {
     let mut hasher = imp::Hasher::new(algorithm);
-    hasher.write_all(data).expect("Could not write hash data");
+    hasher
+        .write_all(data)
+        .and_then(|_| hasher.flush())
+        .expect("Could not write hash data");
     hasher.finish()
+}
+
+/// Helper function for `Hasher` which generates a cryptographic digest from the given
+/// data and algorithm and writes it to `dest`, which must be exactly the
+/// correct length for the digest.
+///
+/// # Examples
+///
+/// ```rust
+/// use crypto_hash::{Algorithm, digest_into};
+///
+/// let data = b"crypto-hash";
+/// let mut dest = [0; 20];
+/// digest_into(Algorithm::SHA1, data, &mut dest);
+/// let expected =
+///     b"\x57\xba\xb6\xe4\x94\x8e\x3a\x06\x09\x3b\x5e\x46\x69\x2b\xa4\x80\xa1\x31\x0c\xfb";
+/// assert_eq!(*expected, dest)
+/// ```
+pub fn digest_into(algorithm: Algorithm, data: &[u8], dest: &mut [u8]) {
+    let mut hasher = imp::Hasher::new(algorithm);
+    hasher
+        .write_all(data)
+        .and_then(|_| hasher.flush())
+        .expect("Could not write hash data");
+    hasher.finish_into(dest);
 }
 
 /// Helper function for `Hasher` which generates a cryptographic digest serialized in


### PR DESCRIPTION
* This avoids needing to allocate a vector for every hash on Windows and
  Linux. The CommonCrypto API will work but still allocates a vector.

* The buffer must match the digest size exactly or panic. An undersized
  buffer would violate Rust safety guarantees, but an oversized buffer
  could also be problematic if, e.g., the user passed a 32 byte buffer
  into a 20 byte digest without zeroing it first.

* The main benefit is performance when hashing enormous numbers of
  values, but this can also be more ergonomic in certain cases.
  Consider:

```
struct Oid {
  sha1: [u8 ; 20],
}

fn one() {
  let mut oid = Oid::default();
  // ...
  hasher.finalize_into(&mut oid.sha1);
}

// vs

fn two() {
  let mut oid = Oid::default();
  // ...
  let digest = hasher.finalize();
  oid.sha1.copy_from_slice(&digest);
}
```

* Also fix a bug in the helpers in `lib.rs` which should call `flush`
  after writing to the Hasher.