### PR TITLE
Introduced `CRYPTO_HASH_FORCE_OPENSSL` env

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,6 @@ appveyor = { repository = "malept/crypto-hash" }
 
 [dependencies]
 hex = "0.4"
-
-[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 commoncrypto = "0.2"
-
-[target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["minwindef", "wincrypt"] }
-
-[target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
 openssl = "0.10"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,17 @@
+use std::env;
+
+fn main() {
+    if env::var("CRYPTO_HASH_FORCE_OPENSSL").is_ok() {
+        println!("cargo:rustc-cfg=feature=\"openssl\"");
+        return;
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    println!("cargo:rustc-cfg=feature=\"commoncrypto\"");
+
+    #[cfg(target_os = "windows")]
+    println!("cargo:rustc-cfg=feature=\"winapi\"");
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios")))']
+    println!("cargo:rustc-cfg=feature=\"openssl\"");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,23 +43,23 @@
 
 #![warn(missing_docs)]
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(feature = "commoncrypto")]
 extern crate commoncrypto;
 extern crate hex;
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "windows")))]
+#[cfg(feature = "openssl")]
 extern crate openssl;
-#[cfg(target_os = "windows")]
+#[cfg(feature = "winapi")]
 extern crate winapi;
 
 use std::io::Write;
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(feature = "commoncrypto")]
 #[path = "imp/commoncrypto.rs"]
 mod imp;
-#[cfg(target_os = "windows")]
+#[cfg(feature = "winapi")]
 #[path = "imp/cryptoapi.rs"]
 mod imp;
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "windows")))]
+#[cfg(feature = "openssl")]
 #[path = "imp/openssl.rs"]
 mod imp;
 


### PR DESCRIPTION
Idea of this environment variable is simple: let force cargo to link crypto_hash against OpenSSL. At any platform.