### PR TITLE
Port from winapi to windows-sys, migrate to Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ hex = "0.4"
 commoncrypto = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3", features = ["minwindef", "wincrypt"] }
+windows-sys = { version = "0.45.0", features = ["Win32_Foundation", "Win32_Security_Cryptography"] }
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
 openssl = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "crypto-hash"
 version = "0.3.4"
+edition = "2018"
 authors = ["Mark Lee"]
 description = "A wrapper for OS-level cryptographic hash functions"
 documentation = "https://docs.rs/crypto-hash"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,14 +43,6 @@
 
 #![warn(missing_docs)]
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
-extern crate commoncrypto;
-extern crate hex;
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "windows")))]
-extern crate openssl;
-#[cfg(target_os = "windows")]
-extern crate winapi;
-
 use std::io::Write;
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]


### PR DESCRIPTION
`windows-sys` is the official microsoft api bindings and so should be preferred over `winapi`.